### PR TITLE
Fix login form display on page reload and adds loader

### DIFF
--- a/frontend/src/components/layout/GuestLayout.tsx
+++ b/frontend/src/components/layout/GuestLayout.tsx
@@ -1,8 +1,20 @@
 import { Outlet, Navigate } from "react-router-dom";
 import useAuthContext from "../../hooks/useAuthContext";
+import Spinner from "../ui/Spinner";
 
 export default function GuestLayout() {
-  const { user } = useAuthContext()
+  const { user, sessionVerified } = useAuthContext()
 
-  return !user ? <Outlet /> : <Navigate to={'/'} />
+  if (sessionVerified && !user) {
+    return (
+      <div className="w-full h-screen min-h-[300px] -mt-5 justify-center rounded-md text-2xl font-bold leading-9 tracking-tight text-gray-900 flex items-center gap-x-3 hover:cursor-progress pointer-events-none select-none">
+        <div className="scale-150">
+          <Spinner loading={true} />
+        </div>
+        <span>Authenticating...</span>
+      </div>
+    )
+  } else {
+    return !user ? <Outlet /> : <Navigate to={'/'} />
+  }
 }


### PR DESCRIPTION
## Pull Request Description

**Problem:**
When the page was refreshed, the login form briefly appeared before redirecting the user to the dashboard. This resulted in a confusing user experience.

**Solution:**
A solution was implemented to display a loader during the login process and prevent the login form from being displayed when the page is refreshed. Now, the authentication flow is smoother and clearer for users.

**Changes Made:**
- Added a state called `sessionVerified` to track whether the user's session has persisted.
- Used this state to display a loader during the login process.
- Made modifications to the `GuestLayout` component to handle the display behavior appropriately.

**Loader screenshot:**
![image](https://github.com/justnixx/laravel-breeze-api-react/assets/88900534/e727c656-0aa3-417c-bf85-09e473f1458f)

**How to Test:**
1. Log in or register as a user.
2. Refresh the page.
3. Note that a loader is now displayed during the login process, and the login form is not shown before the redirection.

**Additional Note:**
I would like to express my gratitude for providing this repository publicly. It has been a valuable experience contributing to this project.